### PR TITLE
修复非标准图片base64格式导致图像显示错误

### DIFF
--- a/dots_ocr/utils/image_utils.py
+++ b/dots_ocr/utils/image_utils.py
@@ -68,7 +68,7 @@ def PILimage_to_base64(image, format='PNG'):
     buffered = BytesIO()
     image.save(buffered, format=format)
     base64_str = base64.b64encode(buffered.getvalue()).decode('utf-8')
-    return f"data:image;base64,{base64_str}"
+    return f"data:image/{format.lower()};base64,{base64_str}"
 
 
 def to_rgb(pil_image: Image.Image) -> Image.Image:


### PR DESCRIPTION
在 `dots_ocr/utils/image_utils.py`  中的 `PILimage_to_base64` 方法中，函数返回的是：
```python
return f"data:image;base64,{base64_str}"
```
导致图片转换后的base64格式为：

<img width="1866" height="936" alt="image" src="https://github.com/user-attachments/assets/ab01feed-22a2-46dc-a8e8-3ae5b4a0a8f3" />

正确的图像base64返回格式应该指明图像格式：

```python
return f"data:image/{format.lower()};base64,{base64_str}"
```

修复后的结果：

<img width="1819" height="877" alt="image" src="https://github.com/user-attachments/assets/d6569f29-c07b-439d-83df-fa5d79301cd6" />
