### PR TITLE
修复 List-item 处理逻辑错误

### DIFF
--- a/dots_ocr/utils/format_transformer.py
+++ b/dots_ocr/utils/format_transformer.py
@@ -171,6 +171,8 @@ def layoutjson2md(image: Image.Image, cells: list, text_key: str = 'text', no_pa
             text_items.append(f"![]({image_base64})")
         elif cell['category'] == 'Formula':
             text_items.append(get_formula_in_markdown(text))
+        elif cell['category'] == 'List-item':
+            text_items.append(text.strip())
         else:            
             text = clean_text(text)
             text_items.append(f"{text}")


### PR DESCRIPTION
测试样例文件：

[2507.00101v1.pdf](https://github.com/user-attachments/files/21656695/2507.00101v1.pdf)

当 json 解析结果中存在 `List-item` 时：

```json
  {
    "bbox": [
      236,
      814,
      1502,
      1058
    ],
    "category": "List-item",
    "text": "* `compute DFReg loss (weights)`: Computes the histogram-based penalty $\\sum_i \\rho_i^2$ given a 1D tensor of weights. This function implements the core DFReg regularization term.\n* `get conv weights (model)`: Iterates through the model layers to extract all convolutional weights, which are flattened and concatenated to estimate the empirical density.\n* `train step(...)`: Computes the standard task loss (e.g., cross-entropy) and adds the DFReg penalty scaled by $\\alpha$. This function replaces or extends the standard optimization step."
  },
```

在 `format_transformer.py` 中的 `layoutjson2md` 函数，缺少对解析结构中 `List-item` 的处理逻辑，以 `clean_text()` 方法处理 `List-item` 会导致列表的结构不符合预期：

<img width="1862" height="912" alt="image" src="https://github.com/user-attachments/assets/4665e685-5ca5-4eb3-b2c5-5927a13b8514" />

因此对  `layoutjson2md` 函数添加额外逻辑：

```python
        elif cell['category'] == 'List-item':
            text_items.append(text.strip())
```

只需要处理掉 `text` 中的空格即可，保留 `\n` 维持原有的结构。

添加处理后的结果：

<img width="1817" height="910" alt="image" src="https://github.com/user-attachments/assets/ec709777-8059-441e-ad34-301b87c7dfc7" />


