### PR TITLE
Fix not used arguments in demo_vllm.py

### DIFF
--- a/demo/demo_vllm.py
+++ b/demo/demo_vllm.py
@@ -29,10 +29,11 @@ def main():
     response = inference_with_vllm(
         image,
         prompt, 
-        ip="localhost",
-        port=8000,
+        ip=args.ip,
+        port=args.port,
         temperature=0.1,
         top_p=0.9,
+        model_name=args.model_name,
     )
     print(f"response: {response}")
 


### PR DESCRIPTION
In demo/demo_vllm.py, we have arguments like  `--ip`, `--port`, but these arguments are never used.

This pr fixes this problem.