### PR TITLE
Fix bug json parse fail

### DIFF
--- a/dots_ocr/parser.py
+++ b/dots_ocr/parser.py
@@ -164,8 +164,26 @@ class DotsOCRParser:
         prompt = self.get_prompt(prompt_mode, bbox, origin_image, image, min_pixels=min_pixels, max_pixels=max_pixels)
         if self.use_hf:
             response = self._inference_with_hf(image, prompt)
+            for _ in range(3):
+                try:
+                    data = json.loads(response)
+                    if not isinstance(data, list):
+                        raise json.JSONDecodeError
+                    break
+                except json.JSONDecodeError as _:
+                    image = image.resize((int(image.width*0.95), int(image.height*0.95)))
+                    response = self._inference_with_hf(image, prompt)
         else:
             response = self._inference_with_vllm(image, prompt)
+            for _ in range(3):
+                try:
+                    data = json.loads(response)
+                    if not isinstance(data, list):
+                        raise json.JSONDecodeError
+                    break
+                except json.JSONDecodeError as _:
+                    image = image.resize((int(image.width*0.95), int(image.height*0.95)))
+                    response = self._inference_with_vllm(image, prompt)
         result = {'page_no': page_idx,
             "input_height": input_height,
             "input_width": input_width

--- a/dots_ocr/parser.py
+++ b/dots_ocr/parser.py
@@ -164,26 +164,24 @@ class DotsOCRParser:
         prompt = self.get_prompt(prompt_mode, bbox, origin_image, image, min_pixels=min_pixels, max_pixels=max_pixels)
         if self.use_hf:
             response = self._inference_with_hf(image, prompt)
-            for _ in range(3):
+            for i in range(3):
                 try:
                     data = json.loads(response)
                     if not isinstance(data, list):
                         raise json.JSONDecodeError
                     break
                 except json.JSONDecodeError as _:
-                    image = image.resize((int(image.width*0.95), int(image.height*0.95)))
-                    response = self._inference_with_hf(image, prompt)
+                    response = self._inference_with_hf(image.resize((int(image.width*(0.95-0.05*i)), int(image.height*(0.95-0.05*i)))), prompt)
         else:
             response = self._inference_with_vllm(image, prompt)
-            for _ in range(3):
+            for i in range(3):
                 try:
                     data = json.loads(response)
                     if not isinstance(data, list):
                         raise json.JSONDecodeError
                     break
                 except json.JSONDecodeError as _:
-                    image = image.resize((int(image.width*0.95), int(image.height*0.95)))
-                    response = self._inference_with_vllm(image, prompt)
+                    response = self._inference_with_vllm(image.resize((int(image.width*(0.95-0.05*i)), int(image.height*(0.95-0.05*i)))), prompt)
         result = {'page_no': page_idx,
             "input_height": input_height,
             "input_width": input_width


### PR DESCRIPTION
# Bug描述
LLM的输出有时不是严格的json格式，导致页面解析失败，无法得到有效的`md_content_no_hf`

# 复现方法
用例为图书《你可以是自己的医生——居家护理常见病》(ISBN:978-7-5470-0405-0)的PDF文件，页面索引号135，具体输出见下方

# 解决方法
经过反复测试，略微缩小图像尺寸可以有效解决问题。图中展示了llm的首次输出和图像0.95倍缩放后的llm输出，经过一次图像缩放修正了llm输出的json格式
<img width="780" height="720" alt="图片" src="https://github.com/user-attachments/assets/49823874-fe2a-4e83-8851-971704a320a1" />
