### PR TITLE
fix dimensions of image generated by parser.py

### DIFF
--- a/dots_ocr/parser.py
+++ b/dots_ocr/parser.py
@@ -7,7 +7,7 @@ import argparse
 
 from dots_ocr.model.inference import inference_with_vllm
 from dots_ocr.utils.consts import image_extensions, MIN_PIXELS, MAX_PIXELS
-from dots_ocr.utils.image_utils import get_image_by_fitz_doc, fetch_image, smart_resize
+from dots_ocr.utils.image_utils import get_image_by_fitz_doc, fetch_image
 from dots_ocr.utils.doc_utils import fitz_doc_to_image, load_images_from_pdf
 from dots_ocr.utils.prompts import dict_promptmode_to_prompt
 from dots_ocr.utils.layout_utils import post_process_output, draw_layout_on_image, pre_process_bboxes


### PR DESCRIPTION
After image ocr with --no_fitz_preprocess a jsonl file is generated with wrong image dimensions to the original because smart_resize is used in the parser.py script. As per https://arxiv.org/abs/2307.06304 NaViT can ingest any dimension image so no need for smart_resize.